### PR TITLE
add unit test for files opened

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
 use std::env;
 use std::fs::File;
 
-fn comm() -> Result<String, String> {
-    let args: Vec<String> = env::args().collect();
+fn comm(args: Vec<String>) -> Result<String, String> {
     if args.len() < 3 {
         return Err("comm needs at least two arguments to compare files!".to_string());
     }
@@ -26,8 +25,23 @@ fn comm() -> Result<String, String> {
     return Ok(format!("opened {} files", files_opened));
 }
 
+#[cfg(test)]
+mod comm_tests {
+    use super::*;
+    #[test]
+    fn test_files_opened() {
+        let test_args = vec![
+            "comm".to_string(),
+            "./testdata/foo.txt".to_string(),
+            "./testdata/bar.txt".to_string(),
+        ];
+        assert_eq!(comm(test_args), Ok("opened 2 files".to_string()));
+    }
+}
+
 fn main() {
-    match comm() {
+    let args: Vec<String> = env::args().collect();
+    match comm(args) {
         Ok(result) => println!("{}", result),
         Err(err) => println!("error: {}", err),
     }


### PR DESCRIPTION


---

<details open="true"><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ## TL;DR
> This pull request refactors the `comm` function to take arguments directly and adds a unit test for the `comm` function.
> 
> ## What changed
> The `comm` function was previously using `std::env::args().collect()` to gather command line arguments. This has been changed to take a `Vec<String>` as an argument directly. This makes the function easier to test and more flexible.
> 
> A unit test for the `comm` function has been added. The test checks that the function correctly opens two files and returns a success message.
> 
> ## How to test
> You can run the tests with the command `cargo test`. This will run the new `test_files_opened` test, which should pass if the `comm` function is working correctly.
> 
> ## Why make this change
> This change makes the `comm` function easier to test and more flexible. By taking arguments directly, the function can be used in more contexts and is easier to understand. The added test ensures that the function is working as expected.
</details>